### PR TITLE
Fix typo in grid world data collection

### DIFF
--- a/examples/continuous_grid/random_agent_rollout.py
+++ b/examples/continuous_grid/random_agent_rollout.py
@@ -72,7 +72,7 @@ def main():
         append_buffer(buffer, (S, A, R, S_, done, p, info))
 
         if done:
-            E = env.reset()
+            S = env.reset()
             done = False
             t = 0
         else:


### PR DESCRIPTION
This bug affected the logged dataset from rollout of random policy in the continuous grid world. Specifically, when an episode terminates it fails to record the initial state of the new episode. This affects both the training of state encoders as well as PSRS simulation (which makes use of initial states). 